### PR TITLE
Support Of Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Cassowary/Sources/Tools.swift
+++ b/Cassowary/Sources/Tools.swift
@@ -31,6 +31,8 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 /// THE SOFTWARE.
 
+import func Foundation.fabs
+
 /// value type box for performance optimization
 /// sometimes we may need to wrap  Struct into Class to avoid frequence copy operation
 final class RefBox<Type>{

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Cassowary",
+    products: [
+        .library(
+            name: "Cassowary",
+            targets: ["Cassowary"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Cassowary",
+            path: "Cassowary/Sources"
+        ),
+        .testTarget(
+            name: "CassowaryTests",
+            dependencies: ["Cassowary"],
+            path: "CassowaryTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <a href="https://travis-ci.org/https://travis-ci.org/nangege/Cassowary"><img src="https://travis-ci.org/nangege/Cassowary.svg?branch=master"></a>
 [![Version](https://img.shields.io/cocoapods/v/SwiftCassowary.svg?style=flat)](http://cocoapods.org/pods/SwiftCassowary)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![swiftpm compatible](https://img.shields.io/badge/swiftpm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
 [![](https://img.shields.io/badge/iOS-8.0%2B-lightgrey.svg)]()
 [![Swift 4.0](https://img.shields.io/badge/Swift-4.2-orange.svg)]()
 
@@ -80,6 +81,14 @@ $(SRCROOT)/Carthage/Build/iOS/Cassowary.framework
 ```
 
 For more information about how to use Carthage, please see its [project page](https://github.com/Carthage/Carthage).
+
+### Swift Package Manager
+To install Cassowary for use in a Swift Package Manager-powered tool, script or server-side application, add Cassowary as a dependency to your `Package.swift` file. For more information, please see the [Swift Package Manager documentation](https://github.com/apple/swift-package-manager/tree/master/Documentation).
+
+```swift
+.package(url: "https://github.com/nangege/Cassowary", from: "0.2.0")
+```
+
 
 
 ## Usage


### PR DESCRIPTION
Adds `Package.swift` file and explicitly imports dependency from Foundation because it is not imported implicitly(like in CocoaPods) which enables usage with [SPM](https://swift.org/package-manager).

❗️**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash but that is not allowed in published packages. 
In fact, new tag is enough.

By the way, if you would like me to add instructions about dependency addition with SPM to README file or you would like to get any other information on the topic — fill free to ping me.🙂